### PR TITLE
Add support for docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM debian:stretch-slim as build
+
+# Install our build dependencies
+RUN apt-get update \
+  && apt-get install -y \
+    build-essential \
+    libboost-all-dev \
+    libssl-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY . /usr/local/src
+
+WORKDIR /usr/local/src
+  
+RUN make
+
+FROM debian:stretch-slim
+
+# Install our run dependencies
+RUN apt-get update \
+  && apt-get install -y \
+    build-essential \
+    libboost-all-dev \
+    libssl-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/local/bin
+
+COPY --from=build /usr/local/src/dnsseed .
+
+EXPOSE 53
+EXPOSE 53/udp
+
+ENTRYPOINT ["./dnsseed"]

--- a/README
+++ b/README
@@ -68,6 +68,24 @@ $ iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT --to-port 5353
 If properly configured, this will allow you to run dnsseed in userspace, using
 the -p 5353 option.
 
+DOCKER
+------
+
+Build the docker image by running the following command:
+
+$ docker build -t btcz/bitcoinz-seeder .
+
+Run the docker image with the following command:
+
+$ docker run -d --name bitcoinz-seeder \
+  -p 53:53/udp -p 53:53 btcz/bitcoinz-seeder \
+  -h dnsseed.example.com -n vps.example.com -m email.gmail.com
+
+Run the docker image with a restart policy:
+
+$ docker run -d --restart always --name bitcoinz-seeder \
+  -p 53:53/udp -p 53:53 btcz/bitcoinz-seeder \
+  -h dnsseed.example.com -n vps.example.com -m email.gmail.com
 
 Security Warnings
 -----------------


### PR DESCRIPTION
This commit adds a minimal docker container to build and run the
`dnsseed` library.